### PR TITLE
Date to objectId conversion does not support unix epoch

### DIFF
--- a/collection-growth-per-period.js
+++ b/collection-growth-per-period.js
@@ -1,5 +1,14 @@
 var byteToGigs = bytes => bytes / 1073741824;
-var dateToObjectId = date => ObjectId(Math.floor(date/1000).toString(16) + "0000000000000000");
+var dateToObjectId = date => {    
+    var datePart = Math.floor(date/1000).toString(16);
+    
+    // Add support for dates down to 1970-01-01 (Unix epoch)
+    // The datePart MUST always represent 4 bytes.
+    while(datePart.length < 8) 
+        datePart = '0' + datePart;
+        
+    return ObjectId(datePart + "0000000000000000");
+}
 
 var countItemsCreated = function(collection, startDate, endDate) {
     var startId = dateToObjectId(startDate);

--- a/delete-from-collection-by-objectid-date-component.js
+++ b/delete-from-collection-by-objectid-date-component.js
@@ -1,4 +1,13 @@
-var dateToObjectId = date => ObjectId(Math.floor(date/1000).toString(16) + "0000000000000000");
+var dateToObjectId = date => {    
+    var datePart = Math.floor(date/1000).toString(16);
+    
+    // Add support for dates down to 1970-01-01 (Unix epoch)
+    // The datePart MUST always represent 4 bytes.
+    while(datePart.length < 8) 
+        datePart = '0' + datePart;
+        
+    return ObjectId(datePart + "0000000000000000");
+}
 
 var allDocumentsCreatedBefore = date => {
     return {_id : {$lt: dateToObjectId(date)}};


### PR DESCRIPTION
Converting a date close to the unix epoch results in an integer of less than 4 bytes. This is fixed by padding the resulting hexidecimal representation.